### PR TITLE
Exempt internal/generated links from htmlproofer

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -16,7 +16,7 @@
         {% if page.url contains link.url %}
           {% assign current = 'current' %}
         {% endif %}
-        <li class="{{ current }}"><a href="{{site.url}}{{site.baseurl}}{{ link.url }}">{{ link.title }}</a></li>
+        <li class="{{ current }}"><a href="{{site.url}}{{site.baseurl}}{{ link.url }}" data-proofer-ignore>{{ link.title }}</a></li>
       {% endfor %}
     </ul>
     <ul class="nav navbar-nav navbar-right">

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -25,7 +25,7 @@ layout: default
       {% else %}
         <div class="media">
           <div class="media-body">
-            <h4 class="media-heading"><a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h4>
+            <h4 class="media-heading"><a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}" title="{{ post.title }}" data-proofer-ignore>{{ post.title }}</a></h4>
             <p>{{ post.excerpt | strip_html | truncate: 160 }}</p>
           </div>
         </div>


### PR DESCRIPTION
The links on the post overview page for posts we host are automatically
generated so they will never fail, we can ignore these. If we don't add
creation time the external resource won't exist yet and Travis will
register a build failure.

Similarly for links we've defined in our site navigation, if we're
addind new pages those pages aren't there yet so the tests would fail.