### PR TITLE
Fix post template

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :clean do
   FileUtils.rm_rf('./_site')
 end
 
-desc 'Validte _site/ with html-proofer'
+desc 'Validate _site/ with html-proofer'
 task :validate do
   HTMLProofer.check_directory('./_site', {
     :url_ignore => [/voxpupuli.org/],

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ desc 'Validte _site/ with html-proofer'
 task :validate do
   HTMLProofer.check_directory('./_site', {
     :url_ignore => [/voxpupuli.org/],
+    :check_html => true,
   }).run
 end
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
     <h1>{{ page.title }}
-      <a style="float: right;" class="btn btn-raised btn-xs" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io/edit/master/{{ page.path}}">Edit <i class="glyphicon glyphicon-edit"></i></a></h1>
+      <a style="float: right;" class="btn btn-raised btn-xs" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io/edit/master/{{ page.path}}">Edit <i class="glyphicon glyphicon-edit"></i></a>
     </h1>
     <p>Published on {{ page.date | date: "%b %-d, %Y" }}{% if page.github_username %} by <a href="https://github.com/{{page.github_username}}">{{ page.github_username }}{% endif %}</a></p>
     <article>


### PR DESCRIPTION
When I turned the HTML checker on in html-proofer it found an additional closing `h1` in the post template that shouldn't have been there.