### PR TITLE
travis: Fix the dependency issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 sudo: false
+before_install:
+  - gem install bundler # the default bundler version on travis is very old and causes dependency issues
 rvm:
   - 2.2
 script: bundle exec rake test


### PR DESCRIPTION
For whatever reason the old Bundler version with this version of Ruby pulls in a completely broken set of dependencies. Upgrading bundler seems to help. Travis ought to keep more up to date with this in their images.