### PR TITLE
add top_scope_facts and legacy_facts linters

### DIFF
--- a/_data/tools/puppet-lint.json
+++ b/_data/tools/puppet-lint.json
@@ -145,6 +145,16 @@
       "description": "A puppet-lint plugin to check if resources exist outside of a class or defined type."
     },
     {
+      "name": "top_scope_facts ",
+      "url": "https://github.com/mmckinst/puppet-lint-top_scope_facts-check",
+      "description": "A puppet-lint plugin to check for top scope facts that should use the facts hash instead."
+    },
+    {
+      "name": "legacy_facts",
+      "url": "https://github.com/mmckinst/puppet-lint-legacy_facts-check",
+      "description": "A puppet-lint plugin to check for legacy facts that have been replaced with new structured facts."
+    },
+    {
       "name": "resource_reference_outside_class",
       "url": "https://github.com/voxpupuli/puppet-lint-reference_on_declaration_outside_of_class-check.git",
       "description": "A puppet-lint plugin to check for references which are declared outside of the class where the reference is used."


### PR DESCRIPTION
useful to take advantage of the structured facts and `$facts` hash in
puppet 4 but puppet 3 users can also make use of them if they've
configured puppet correctly or are running a new version of facter

* top_scope_facts - lints for facts like `$::operatingsystem` and
replaces them with `$facts['operatingsystem']` .

* legacy_facts - lints for so called legacy facts like
`$facts['operatingsystemmajrelease']` or `$::operatingsystemmajrelease`
and replaces them with the new fancy structured fact like
`$facts['os']['release']['major']`

ref https://github.com/voxpupuli/plumbing/issues/21