### PR TITLE
add github PR stats jekyll plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: ruby
 sudo: false
 before_install:
-- gem install bundler
+  - gem install bundler
 dist: trusty
 rvm:
-- 2.4
+  - 2.4
 script: bundle exec rake test
 notifications:
   email: false
 env:
   global:
-  - secure: sCx6hjf1f/JuBSOCKkDXCPrM5CZehHs/Ibp9Z5vYX0ZjPSlWD9CKt/emupslD1axmImIjK/M99bvHlF3kAgTxhHKyHzvk63M7IcmTNStGbQj9WPTwHXLjwoKVa+gtMCW1XtlyfeyTC5HHAnEExduvw2x7f/am8/4qq2varOQbG8=
-  - secure: iEHH9GSm02uKhVy04ymms5ydFsww2UmBIFKJwxmEvND1mUzABqBf+v+emMP7XPSLs/L3v+XyAy08kWM4n132Ul/h/XTDeM3W15CRKCABxhPesxzoczki95eJ6E6hMF+4HlfTXSGLKtTb6R18fvtbq0pSJOL4SNpd7YsIe+VSnmY=
+    - GH_CLIENT_ID='client_id-foo'
+    - GH_CLIENT_SECRET='client_secret-bar'

--- a/_config.yml
+++ b/_config.yml
@@ -34,3 +34,9 @@ navigation:
     url: /posts/
 
 exclude: ["Gemfile", "Gemfile.lock", "LICENSE", "README.md", "CNAME", "README.md", "vendor"]
+
+# static fallback stats values
+stats:
+  collaborators: 30
+  repos: 119
+  pr: 183

--- a/_plugins/github_pr_stats.rb
+++ b/_plugins/github_pr_stats.rb
@@ -9,6 +9,9 @@ module Jekyll
       api_url = 'https://api.github.com/orgs/voxpupuli/repos?per_page=100'
       oauth_client_id = ENV['GH_CLIENT_ID'] ||= nil
       oauth_client_secret = ENV['GH_CLIENT_SECRET'] ||= nil
+      p('debug: ENV', ENV)
+      log("debug: ENV['GH_CLIENT_ID'] = #{ENV['GH_CLIENT_ID']}")
+      log("debug: ENV['GH_CLIENT_SECRET'] = #{ENV['GH_CLIENT_SECRET']}")
       @auth_suffix = nil
       if oauth_client_id && oauth_client_secret
         @auth_suffix = "&client_id=#{oauth_client_id}&client_secret=#{oauth_client_secret}"

--- a/_plugins/github_pr_stats.rb
+++ b/_plugins/github_pr_stats.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+require 'net/http'
+
+module Jekyll
+  # fetch open pull requests
+  class GithubPRStatsTag < Liquid::Tag
+    def initialize(tag_name, _args, tokens)
+      super
+      api_url = 'https://api.github.com/orgs/voxpupuli/repos?per_page=100'
+      oauth_client_id = ENV['GH_CLIENT_ID'] ||= nil
+      oauth_client_secret = ENV['GH_CLIENT_SECRET'] ||= nil
+      @auth_suffix = nil
+      if oauth_client_id && oauth_client_secret
+        @auth_suffix = "&client_id=#{oauth_client_id}&client_secret=#{oauth_client_secret}"
+      end
+      @api_url = api_url + @auth_suffix.to_s
+      @repos = 0
+      @pull_reqs = 0
+    end
+
+    def query(url: @api_url, page: 1)
+      url = URI.parse(url + "&page=#{page}")
+      req = Net::HTTP::Get.new(url.to_s)
+      req['Accept'] = 'application/vnd.github.v3+json'
+      req['User-Agent'] = 'voxpupuli.org github API'
+      res = Net::HTTP.start(url.host, url.port, use_ssl: true) { |http| http.request(req) }
+
+      # see if there are more pages
+      next_page = nil
+      if res['link']
+        res['link'].split(',').each do |link|
+          # also catch possibly nested quoting
+          if link.match?(%r{rel=(\\|)"next(\\|)"})
+            next_url = URI.extract(link)[0]
+            next_page = next_url.match(%r{(&|\?)page=(?<page>[0-9]+)})[:page]
+          end
+        end
+      end
+      [next_page, JSON.parse(res.body)]
+    end
+
+    def process_repos(repositories = {})
+      @repos += repositories.length
+      # iterate over the repositories
+      repositories.each do |repo|
+        log("  [+] processing #{repo['name']}...")
+        pull_url = repo['pulls_url'].chomp('{/number}')
+        pull_url += '?state=open&per_page=100'
+        pull_url += @auth_suffix
+        next_page = 1
+        loop do
+          next_page, pull_requests = query(url: pull_url, page: next_page)
+          @pull_reqs += pull_requests.length if pull_requests.is_a?(Array)
+          break unless next_page
+        end
+      end
+    end
+
+    def log(msg = '')
+      p('github_pr_stats.rb: ' + msg.to_s)
+    end
+
+    def render(_context)
+      # do not even attempt to continue w/o privileged api access
+      return Jekyll.configuration['stats']['pr'] unless @auth_suffix
+
+      log('fetching data from github API, this may take a while...')
+
+      begin
+        next_page = 1
+        loop do
+          next_page, repositories = query(url: @api_url, page: next_page)
+          process_repos(repositories)
+          break unless next_page
+        end
+
+        # some build output
+        log("github_pr_stats.rb: parsed #{@repos} repositories with #{@pull_reqs} PRs")
+
+        return @pull_reqs
+      rescue => err
+        p(err)
+        return Jekyll.configuration['stats']['pr']
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('github_pr_stats', Jekyll::GithubPRStatsTag)

--- a/_plugins/github_repo_stats.rb
+++ b/_plugins/github_repo_stats.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'net/http'
+
+module Jekyll
+  # fetch repository count
+  class GithubRepoStatsTag < Liquid::Tag
+    def initialize(tag_name, _args, tokens)
+      super
+    end
+
+    def render(_context)
+      api_url = 'https://api.github.com/orgs/voxpupuli'
+
+      oauth_client_id = ENV['GH_CLIENT_ID'] ||= nil
+      oauth_client_secret = ENV['GH_CLIENT_SECRET'] ||= nil
+
+      if oauth_client_id && oauth_client_secret
+        api_url += "?client_id=#{oauth_client_id}&client_secret=#{oauth_client_secret}"
+      end
+
+      begin
+        url = URI.parse(api_url)
+        req = Net::HTTP::Get.new(url.to_s)
+        req['Accept'] = 'application/vnd.github.v3+json'
+        req['User-Agent'] = 'voxpupuli.org github API'
+        res = Net::HTTP.start(url.host, url.port, use_ssl: true) { |http| http.request(req) }
+        return JSON.parse(res.body)['public_repos']
+      rescue => err
+        p(err)
+        return Jekyll.configuration['stats']['repos']
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('github_repo_stats', Jekyll::GithubRepoStatsTag)

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ layout: default
         collaborators
       </div>
       <div class="panel-body">
-        <h1 id="members-count">68</h1>
+        <h1 id="members-count">{{ site.stats['collaborators'] }}</h1>
       </div>
     </div>
   </div>
@@ -19,7 +19,7 @@ layout: default
         repositories
       </div>
       <div class="panel-body">
-        <h1 id="repository-count">86</h1>
+        <h1 id="repository-count">{% github_repo_stats %}</h1>
       </div>
     </div>
   </div>
@@ -29,7 +29,7 @@ layout: default
         open pull requests
       </div>
       <div class="panel-body">
-        <h1 id="pr-count">74</h1>
+        <h1 id="pr-count">{% github_pr_stats %}</h1>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Also introduce the "stats" config key for backup values
This way only the _config.yml needs to be modified when manually
updating the values.

The only thing left to do is:
adding the encrypted GH_CLIENT_ID and GH_CLIENT_SECRET ENV vars to .travis.yml.

Maybe @bastelfreak can help out here? :)