### PR TITLE
add a note about parameter alignment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -160,3 +160,4 @@ There are a few things that can be checked if you review a pull request against 
 * You can merge your own PR if it was approved by someone else and travis is green. Don't merge if either one of those conditions are not true
 * It's okay to approve code regardless if travis is still running or not. The code won't be merged if travis fails after the PR got approved
 * If you can supply one or multiple values for an attribute it's common practice to enforce the datatype for one value and an array of that datatype. An example for string is `Variant[String[1],Array[String[1]]]`. This can be used in the Puppet code as `[$var].flatten()`
+* The parameter section should always be aligned at the `=` char


### PR DESCRIPTION
Our style is currently a bit inconsistent. Sometimes we just use a single whitespace before/after `=`, sometimes everything is aligned at =. I prosed the second way for the style guide, since that is more common in our modules.