### PR TITLE
Shorten the header a bit

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,11 +20,9 @@ kramdown:
 
 
 navigation:
-  - title: Home
-    url: /
   - title: Code of Conduct
     url: /coc/
-  - title: Docs
+  - title: Documentation
     url: /docs/
   - title: Security
     url: /security/

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ navigation:
     url: /
   - title: Code of Conduct
     url: /coc/
-  - title: Documentation
+  - title: Docs
     url: /docs/
   - title: Security
     url: /security/


### PR DESCRIPTION
With the additional *Leadership* link in there, I'm a little concerned
that the header might be too wide. If so, we can shorten it easily by
not using the full word here.