### PR TITLE
mention hiera5 compatibility for data-in-modules

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -149,7 +149,7 @@ There are a few things that can be checked if you review a pull request against 
 * Are facts used? They should only be accessed via `$facts[]` or [fact()](https://github.com/puppetlabs/puppetlabs-stdlib#fact) from stdlib, but not topscope variables
 * In the majority of cases, variables shouldn't be accessed via topscope: $::modulename::$param. Instead do: $modulename::$param
 * Are datatypes from stdlib used? Ensure that lowest supported stdlib version is 4.13.1. Check if a newer version introduced the used datatype
-* Are hiera yaml files added for data-in-modules? Ensure that the lowest supported Puppet version is 4.10.0
+* Are hiera yaml files added for data-in-modules? Ensure that the lowest supported Puppet version is 4.10.0 and that the data is compatible with [hiera 5](https://puppet.com/docs/puppet/5.3/hiera_migrate.html#use-cases-for-upgrading-to-hiera-5)
 * Are there new params with datatype Hash or Array? If possible, they should default to empty Hash/Array instead of undef. You can also enforce the datastructure like Array[String]
 * Are there new params with datatype Boolean? The default value is a tricky decision which needs careful reviewing. Sometimes a True/False is the better approach, sometimes undef
 * Is this a bugfix? Write the Pull Request Title in a way that users can easily identify if they are impacted or not


### PR DESCRIPTION
I added the link to the puppet 5.3 documentation on purpose. It nicely
describes the differences between Hiera 3 and 5 and how people can
migrate. This is probably helpful if somebody contributed hiera 3 syntax
by accident. We can than simply link to the docs mentioned in this
document.