### PR TITLE
(GH-195) Fix license link 404

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,6 +4,6 @@
       Get in touch! <a href="mailto:voxpupuli@groups.io">Mailinglist voxpupuli@groups.io</a> (<a href="https://groups.io/g/voxpupuli/topics">Webinterface</a>) |
       <a href="irc://irc.freenode.net/voxpupuli">#voxpupuli on irc.freenode.net</a> (<a href="https://webchat.freenode.net/?channels=%23voxpupuli">Webinterface</a>) |
       <a href="https://puppetcommunity.slack.com/messages/voxpupuli/">Vox Pupuli on Slack</a> |
-      <a href="license/">Dual license (CC BY-SA 4.0 + Apache 2.0)</a></p>
+      <a href="https://voxpupuli.org/license/">Dual license (CC BY-SA 4.0 + Apache 2.0)</a></p>
   </div>
 </div>


### PR DESCRIPTION
Without this patch, the link is relative and works on the home page and
404's everywhere else.