### PR TITLE
Add a notice for the PMC group

### DIFF
--- a/elections/index.md
+++ b/elections/index.md
@@ -19,7 +19,8 @@ Management Committee (PMC).
 care of the Code of Conduct and its values, participate in strategic planning,
 and decision making using [lazy consensus][lazy], amongst other things.
 
-The current list of PMC members can be found on [GitHub][maintainers].
+The current list of PMC members can be found on [GitHub][maintainers]. You need
+to be part of the Vox Pupuli GitHub organisation to access the list.
 
 ## Terms and Dates
 


### PR DESCRIPTION
Fixes #194
... at least in parts. This commit adds a mention to our governance
document. People that are not part of our GitHub org cannot access
teams.