### PR TITLE
Add a series of short blog posts

### DIFF
--- a/_posts/2023-04-28-drop-puppet-6.md
+++ b/_posts/2023-04-28-drop-puppet-6.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: Vox Pupuli Changelog - Dropping Puppet 6 support
+date: 2023-04-28
+github_username: bastelfreak
+twitter_username: bastelsblog
+category: changelog
+---
+
+Hi!
+
+This is our new blog series, where we inform you about changes within Vox Pupuli itself or our codebase!
+
+Starting today, 2023-04-28, we are dropping Puppet 6 support from our modules. Puppet 6 is end
+of life since 2023-02-28. Puppet's policy on EOL is available at:
+[Puppet Enterprise Lifecycle Policy](https://www.puppet.com/products/puppet-enterprise/support-lifecycle).
+Each of our modules received a PR with the title `Drop Puppet 6 support`. The
+change will be released as a major version. Puppet 6 AIO agents
+[shipped Ruby 2.5](https://www.puppet.com/docs/pe/2019.8/component_versions_in_recent_pe_releases.html).
+With dropping Puppet 6 we will also require Ruby 2.6. That's the ruby version
+used in Puppetserver 7. We will update our RuboCop configuration to default to
+Ruby 2.7 in the next weeks.

--- a/_posts/2023-06-09-module-deprecation.md
+++ b/_posts/2023-06-09-module-deprecation.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: Vox Pupuli Changelog - Deprecating old modules
+date: 2023-06-09
+github_username: bastelfreak
+twitter_username: bastelsblog
+category: changelog
+---
+
+Hi!
+
+As a result of a set of discussions on IRC and on the mailinglist. We will archive the
+following modules due to lack of community engagement:
+
+* https://github.com/voxpupuli/puppet-system
+* https://github.com/voxpupuli/puppet-windows_autoupdate
+* https://github.com/voxpupuli/puppet-windows_eventlog
+* https://github.com/voxpupuli/puppet-windows_power
+* https://github.com/voxpupuli/puppet-windows_env
+* https://github.com/voxpupuli/puppet-sslcertificate
+* https://github.com/voxpupuli/puppet-msoffice
+
+The modules will stay available on Github and on the Forge. They will be marked
+as deprecated on the forge. We can unarchive the repos any time in case someone
+steps up and wants to keep maintaining them.

--- a/_posts/2023-07-01-stdlib-9.md
+++ b/_posts/2023-07-01-stdlib-9.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: Vox Pupuli Changelog - Use/Require puppetlabs/stdlib 9
+date: 2023-07-01
+github_username: bastelfreak
+twitter_username: bastelsblog
+category: changelog
+---
+
+Hi!
+
+Starting Today, 2023-07-01, we are implementing puppetlabs/stdlib 9 support in our
+modules. The 9 release dropped a lot of functions or namespaced them. Wherever
+necessary, we will require puppetlabs/stdlib 9. In those cases we will do a
+major release of the module. We will try to combine this with the major release
+required for dropping Puppet 6 support. 
+
+All modules that depend on stdlib 9.x will receive a PR with the title `puppetlabs/stdlib: Require 9.x`.
+As modules are made compatible with stdlib 9.x will recieve a PR with the title `puppetlabs/stdlib: Allow 9.x`.

--- a/_posts/2023-07-02-puppet-8.md
+++ b/_posts/2023-07-02-puppet-8.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Vox Pupuli Changelog - Add Puppet 8 support
+date: 2023-07-02
+github_username: bastelfreak
+twitter_username: bastelsblog
+category: changelog
+---
+
+Hi!
+
+Today, 2023-07-02, we started to implement Puppet 8 support for our modules.
+This has a few constraints:
+* Puppet 8 AIO packages bundle Ruby 3.2
+* because of that, rspec-puppet unit tests for Puppet 8 run on Ruby 3.2
+* To implement Ruby 3.2 support in our test suite, we had to drop Ruby < 2.7 in some gems
+* Puppet 6 AIO packages bundle Ruby 2.5
+
+Conclusion: we have to drop Puppet 6 before we can add Puppet 8 support.
+
+[modulesync_config 6](https://github.com/voxpupuli/modulesync_config/blob/master/CHANGELOG.md#600-2023-05-12)
+will bring the required changes to our modules to pull in Gems that work on Ruby
+3.2. In most modules it's enough to add Puppet 8 to the metadata.json. That will
+run all unit and acceptance tests on Puppet 8.

--- a/_posts/2023-07-20-voxpupuli-sponsoring.md
+++ b/_posts/2023-07-20-voxpupuli-sponsoring.md
@@ -1,0 +1,48 @@
+---
+layout: post
+title: Vox Pupuli Changelog - Vox Pupuli Sponsoring
+date: 2023-07-20
+github_username: bastelfreak
+twitter_username: bastelsblog
+category: changelog
+---
+
+Hi!
+
+Since [Configuration Management Camp 2023](https://cfgmgmtcamp.eu/), people can
+finally donate to Vox Pupuli!
+
+This was an idea started by nibalizer, meena and daenny in ~ 2015. We wanted to
+join the [Software Freedom Conservancy](https://sfconservancy.org/). That
+didn't work out in the end, for various reasons. Instead, bastelfreak tried to
+bring us into the [Software in the Public Interest](https://www.spi-inc.org/)
+organisation. That failed due to paperwork (like actual paper that has to be
+sent across the world).
+
+Now after many years, we're part of the
+[Open Collective](https://opencollective.com/vox-pupuli). We didn't really know
+what to expect and bastelfreak created some random tiers at GitHub sponsors:
+
+[github.com/sponsors/voxpupuli](https://github.com/sponsors/voxpupuli)
+
+Now a few months later we can say: What the hell?!
+
+People are sending us roughly $200 per month!
+
+*insert party.gif here*
+
+It's amazing to see the support from so many individuals and companies. We want
+to point out [Steffen 'saz' Zieger](https://github.com/saz), he was our first
+sponsor! You might know him from his awesome
+[saz/ssh module](https://forge.puppet.com/modules/saz/ssh).
+
+We promised all bigger sponsors a place on our website (well, bastelfreak did
+that). Now we've so many of them, that we had to adjust our design a
+[few times](https://github.com/voxpupuli/voxpupuli.github.io/pull/306).
+
+Check out [voxpupuli.org/sponsoring](https://voxpupuli.org/sponsoring/) to learn
+who is sponsoring us with money or CI resources and to learn how you can support
+us!
+
+We're so grateful for all of our supporters who enable us to keep the puppet
+community up and running <3

--- a/_posts/2023-08-13-github-2fa.md
+++ b/_posts/2023-08-13-github-2fa.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: Vox Pupuli Changelog - 2FA for our GitHub org
+date: 2023-07-20
+github_username: bastelfreak
+twitter_username: bastelsblog
+category: changelog
+---
+
+Hi!
+
+GitHub will soon enforce two factor authencation for all users in our
+organisation. Most of you already have it enabled. Instead of being locked out
+of our organisation, please enable 2FA!
+
+GitHub announced the 2FA expansion last year:
+
+https://github.blog/2022-05-04-software-security-starts-with-the-developer-securing-developer-accounts-with-2fa/
+
+And the rollout started for some groups in March and will continue until the end of the year:
+
+https://github.blog/2023-03-09-raising-the-bar-for-software-security-github-2fa-begins-march-13/

--- a/_posts/2023-08-14-module-migration.md
+++ b/_posts/2023-08-14-module-migration.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: Vox Pupuli Changelog - Deprecating old modules
+date: 2023-08-14
+github_username: bastelfreak
+twitter_username: bastelsblog
+category: changelog
+---
+
+Hi!
+
+Puppet stepped up and is interested in maintaining some of our (archived)
+windows modules. Today we migrated the following git repositories to them:
+
+* https://github.com/voxpupuli/puppet-windows_env
+* https://github.com/voxpupuli/puppet-sslcertificate
+* https://github.com/voxpupuli/puppet-windows_eventlog
+
+You can see all our archived repos at: https://github.com/orgs/voxpupuli/repositories?q=&type=archived&language=&sort=
+
+Let us know if you're interesting in maintaining any of those projects.


### PR DESCRIPTION
The idea is to release a short blog post from time to time to inform people about changes within Vox Pupuli or our code base. I added a few posts for previous events in this year.