### PR TITLE
deprecation: remove plumbing step

### DIFF
--- a/_docs/deprecated_and_archived_modules.md
+++ b/_docs/deprecated_and_archived_modules.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: Deprecated and Archived Modules
-date: 2019-11-29
+date: 2024-02-08
 summary: Vox Pupuli policy on deprecating and archiving modules
-last_updater: bastelfreak
+last_updater: ekohl
 ---
 
 ## Archived Modules
@@ -24,7 +24,7 @@ The decision to archive a module isn't necessarily final and can be undone.
   * The deprecation issue in that project must be linked
 * The GitHub repository needs to be archived in the GitHub settings
 * On forge.puppet.com the module needs to be archived, with a link to the successor (if available)
-* The module needs to be removed from our [modulesync_config][mc] and [plumbing][pl] setup
+* The module needs to be removed from our [modulesync_config][mc].
 * The Vox Pupuli admins can manage the [org secrets][secrets]. The permission for the archived module needs to be revoked.
 
 ### Currently archived modules
@@ -33,5 +33,4 @@ You can see all archived modules on GitHub: [github.com/orgs/voxpupuli/repositor
 
 [email]: https://groups.io/g/voxpupuli/topics
 [mc]: https://github.com/voxpupuli/modulesync_config/blob/master/managed_modules.yml
-[pl]: https://github.com/voxpupuli/plumbing/blob/master/share/modules
 [secrets]: https://github.com/organizations/voxpupuli/settings/secrets/actions


### PR DESCRIPTION
This file was removed from the repository in https://github.com/voxpupuli/plumbing/commit/83482a85983901d80e2e440951323e7114d498bf