### PR TITLE
Fix edit button consistency

### DIFF
--- a/_includes/edit_button.html
+++ b/_includes/edit_button.html
@@ -1,0 +1,1 @@
+<a style="float: right;" role="button" class="btn btn-outline-primary" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io/edit/master/{{ page.path}}">Edit <i class="fa fa-pencil-square-o"></i></a>

--- a/_layouts/architecture.html
+++ b/_layouts/architecture.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 <h1>{{ page.title }}
-  <a style="float: right;" class="btn btn-raised btn-xs" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io/edit/master/{{ page.path}}">Edit <i class="glyphicon glyphicon-edit"></i></a>
+  {% include edit_button.html %}
 </h1>
 <p>
   <i>Version {{ page.version}}</i><br />

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,6 +4,6 @@ layout: default
 
 <h1>
   {{ page.title }}
-  <a style="float: right;" role="button" class="btn btn-outline-primary" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io/edit/master/{{ page.path}}">Edit <i class="fa fa-pencil-square-o"></i></a>
+  {% include edit_button.html %}
 </h1>
 {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 <h1>{{ page.title }}
-  <a style="float: right;" class="btn btn-raised btn-xs" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io/edit/master/{{ page.path}}">Edit <i class="glyphicon glyphicon-edit"></i></a>
+  {% include edit_button.html %}
 </h1>
 <p>Published on {{ page.date | date: "%b %-d, %Y" }}{% if page.github_username %} by <a href="https://github.com/{{page.github_username}}">{{ page.github_username }}</a>{% endif %}. {% if page.last_updater %}Last updated on {{ page.last_modified_at | date: "%b %-d, %Y" }}{% if page.last_updater %} by <a href="https://github.com/{{page.last_updater}}">{{ page.last_updater }}{% endif %}</a>.{% endif %}</p>
 <article>


### PR DESCRIPTION
The button style is not consistent accross pages, so move the button in its own include file and rely on it where applicable.