### PR TITLE
Fix root uri of the blog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,9 @@ gem 'rake'
 gem 'rubocop', '~> 1.31'
 gem 'rubocop-rake'
 
-# https://github.com/gjtorikian/jekyll-last-modified-at
 group :jekyll_plugins do
+  # https://github.com/gjtorikian/jekyll-last-modified-at
   gem 'jekyll-last-modified-at'
+  # https://github.com/jekyll/jekyll-redirect-from
+  gem 'jekyll-redirect-from'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -38,9 +38,10 @@ navigation:
   - title: Sponsoring
     url: /sponsoring/
   - title: Blog
-    url: /posts/
+    url: /blog/
 
 exclude: ["Gemfile", "Gemfile.lock", "LICENSE", "README.md", "CNAME", "README.md", "vendor"]
 
 plugins:
   - jekyll-last-modified-at
+  - jekyll-redirect-from

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,4 +1,6 @@
 ---
 layout: post-index
 title: All Posts
+redirect_from:
+  - /posts/
 ---


### PR DESCRIPTION
Blog posts are under /blog/... but the blog index is under /posts/, as a
consequence the "Blog" button is not shown as active when a blog post is
shown.

Setup a redirect so that the old URI does not break, and relocate the
blog index in /blog/.
