### PR TITLE
module deprecation: Allow deprecation-discussion on mailinglist

### DIFF
--- a/_docs/deprecated_and_archived_modules.md
+++ b/_docs/deprecated_and_archived_modules.md
@@ -17,7 +17,7 @@ The decision to archive a module isn't necessarily final and can be undone.
 
 ### Deprecation process
 
-* An issue needs to be raised on the module to discuss whether it should be archived or not. The decision will be made by lazy consensus (as described in our governance guidelines)
+* An issue needs to be raised on the module to discuss whether it should be archived or not. An additional post to the [mailing list][email] for better visibility is recommended. The decision will be made by lazy consensus (as described in our governance guidelines)
 * The README.md needs a bold message at the beginning
   * It must mention that the module is archived
   * If a successor exists, that one should be linked to


### PR DESCRIPTION
In the past we used email threads to discuss if we want to deprecate/archive a module. I think this is fine, so this should be documented on our website.