### PR TITLE
Automatically get changes in last day

### DIFF
--- a/_docs/pql_queries.md
+++ b/_docs/pql_queries.md
@@ -124,7 +124,7 @@ and saves reports on a per-day partition. By filtering for the current day we
 avoid scans on other partitions.
 
 ```
-puppet query 'events[certname]{corrective_change = true and report_receive_time > "2024-04-05T06:06:00.000Z" group by certname}'
+puppet query "events[certname]{corrective_change = true and report_receive_time > \"$(date -u --date='1 day ago' +%Y-%m-%dT%H:%M:%S.000Z)\" group by certname}"
 ```
 
 ### Get all inactive nodes


### PR DESCRIPTION
Given that the Events endpoint has a lot of data in it (partitioned by day) ask for only events that occurred in the last day by using the date command to generate the timestamp