### PR TITLE
Consider Debian LTS as supported

### DIFF
--- a/_posts/2024-10-01-debian-11.md
+++ b/_posts/2024-10-01-debian-11.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: Debian LTS support in our modules
+date: 2024-10-01
+github_username: bastelfreak
+category: changelog
+---
+
+In the past, Vox Pupuli decided against supporting [Debian LTS timeframes](https://wiki.debian.org/LTS).
+This was mostly because our CI resources were quite limited back in the days of Travis CI.
+Over the time we got multiple requests from individuals and companies to also support Debian LTS, some of them even willing to sponsor us.
+Some of our modules rely on a puppetserver or bolt, for example [puppet-redis][redis].
+We're now in a situation where Perforce fails to deliver packages in time (see [1][1], [2][2], [3][3]).
+This now brings us to a situation where normal Debian 11 support is gone, but we cannot add Debian 12 support for some modules because Perforce doesn't provide required packages.
+Therefore we consider Debian LTS releases as supported.
+
+[redis]: https://github.com/voxpupuli/puppet-redis/blob/master/spec/acceptance/redis_cli_task_spec.rb
+[1]: https://github.com/puppetlabs/bolt/issues/3280
+[2]: https://github.com/puppetlabs/puppetserver/issues/2837
+[3]: https://github.com/puppetlabs/community/discussions/65


### PR DESCRIPTION
In the past we agreed on not supporting Debian LTS versions, only the standard versions (and I know that I was one of the people that pushed for not supported LTS back then). Debian 11 switched from standard to LTS on 2024-08-15. There are still requests from users to support Debian 11 and I think with the slow response from Puppet about new debian packages it makes sense to reconsider it.

Please respond with :+1: if you agree or with :-1: if you think we shouldn't support the LTS versions. When we've some feedback we can merge this PR or close it.


