### PR TITLE
Add icon and invite to new slack

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,8 +5,7 @@
       <a href="mailto:voxpupuli@groups.io">Mailinglist voxpupuli@groups.io</a> (<a href="https://groups.io/g/voxpupuli/topics">Webinterface</a>) |
       <a href="ircs://irc.libera.chat:6697">#voxpupuli on Libera</a> (<a href="https://web.libera.chat/?#voxpupuli">Webinterface</a>) |
       <a href="https://matrix.to/#/!xKkvgsGCsiWDhqCMMZ:libera.chat">#voxpupuli on Libera via Matrix</a> |
-      <a href="https://puppetcommunity.slack.com/messages/voxpupuli/">Vox Pupuli on Slack</a> 
-        (<a href="https://short.voxpupu.li/puppetcommunity_slack_signup">Join Slack here</a>) |
+      <a href="https://voxpupuli.slack.com/">Vox Pupuli on Slack</a> 
       <a href="https://voxpupuli.org/license/">Dual license (CC BY-SA 4.0 + Apache 2.0)</a></p>
   </div>
 </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,7 +20,7 @@
     <ul class="navbar-nav ms-auto">
       <li class="nav-item"><a class="nav-link{% if page.url contains "/privacy-policy" %} active{% endif %}" href="{{site.url}}{{site.baseurl}}/privacy-policy"> Privacy Policy</a></li>
       <li class="nav-item"><a class="nav-link" href="https://github.com/voxpupuli"><i class="fa fa-github"></i> Github</a></li>
-      <li class="nav-item"><a class="nav-link" href="https://join.slack.com/t/voxpupuli/shared_invite/zt-2qps81elf-mp3bVZJZGqbZfKQTi4Q4bQ"><i class="fa fa-slack"></i> Slack</a></li>
+      <li class="nav-item"><a class="nav-link" href="https://short.voxpupu.li/puppetcommunity_slack_signup"><i class="fa fa-slack"></i> Slack</a></li>
     </ul>
   </div>
   </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,6 +20,7 @@
     <ul class="navbar-nav ms-auto">
       <li class="nav-item"><a class="nav-link{% if page.url contains "/privacy-policy" %} active{% endif %}" href="{{site.url}}{{site.baseurl}}/privacy-policy"> Privacy Policy</a></li>
       <li class="nav-item"><a class="nav-link" href="https://github.com/voxpupuli"><i class="fa fa-github"></i> Github</a></li>
+      <li class="nav-item"><a class="nav-link" href="https://join.slack.com/t/voxpupuli/shared_invite/zt-2qps81elf-mp3bVZJZGqbZfKQTi4Q4bQ"><i class="fa fa-slack"></i> Slack</a></li>
     </ul>
   </div>
   </div>


### PR DESCRIPTION
This is just the raw invite link at this point. As soon as @bastelfreak
gets the shortlink updated, we'll replace it.

Tangent: we should simplify the nav header soon!
