### PR TITLE
revamps navigation menus by adding dropdowns

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,23 +24,60 @@ collections:
   sponsors:
     output: false
 
+# See https://fontawesome.com/search for the icon syntax
 navigation:
-  - title: How to contribute
-    url: /contributing/
-  - title: Code of Conduct
-    url: /coc/
-  - title: Documentation
-    url: /docs/
-  - title: Leadership
-    url: /elections/
-  - title: Security
-    url: /security/
-  - title: Plugins
-    url: /plugins/
+  - title: About
+    entries:
+      - title: Documentation
+        url: /docs/
+        icon: fas fa-book
+      - title: Leadership
+        url: /elections/
+        icon: fas fa-people-group
+      - title: Security
+        url: /security/
+        icon: fas fa-shield-halved
+  - title: Projects
+    entries:
+      - title: Projects Overview
+        url: /projects/
+        icon: fas fa-signs-post
+      - title: Plugins
+        url: /plugins/
+        icon: fas fa-puzzle-piece
+      - title: How to contribute
+        url: /contributing/
+        icon: fas fa-screwdriver-wrench
+      - title: GitHub
+        url: https://github.com/voxpupuli
+        icon: fab fa-github
+  - title: Connect
+    entries:
+      - title: Blog
+        url: /blog/
+        icon: fas fa-newspaper
+      - title: Slack
+        url: https://short.voxpupu.li/puppetcommunity_slack_signup
+        icon: fab fa-slack
+      - title: Other Channels
+        url: /connect/
+        icon: fas fa-comments
+      - title: Code of Conduct
+        url: /coc/
+        icon: fas fa-users
   - title: Sponsoring
     url: /sponsoring/
-  - title: Blog
-    url: /blog/
+    icon: fas fa-money-bill-wave
+
+footer:
+  - title: Privacy Policy
+    url: /privacy-policy/
+  - title: Code of Conduct
+    url: /coc/
+  - title: Security
+    url: /security/
+  - title:  Dual license (CC BY-SA 4.0 + Apache 2.0)
+    url: /license/
 
 exclude: ["Gemfile", "Gemfile.lock", "LICENSE", "README.md", "CNAME", "vendor"]
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,11 +1,18 @@
 <div id="footer">
   <div class="container">
-    <p class="text-muted">
-      Get in touch!
-      <a href="mailto:voxpupuli@groups.io">Mailinglist voxpupuli@groups.io</a> (<a href="https://groups.io/g/voxpupuli/topics">Webinterface</a>) |
-      <a href="ircs://irc.libera.chat:6697">#voxpupuli on Libera</a> (<a href="https://web.libera.chat/?#voxpupuli">Webinterface</a>) |
-      <a href="https://matrix.to/#/!xKkvgsGCsiWDhqCMMZ:libera.chat">#voxpupuli on Libera via Matrix</a> |
-      <a href="https://voxpupuli.slack.com/">Vox Pupuli on Slack</a> 
-      <a href="https://voxpupuli.org/license/">Dual license (CC BY-SA 4.0 + Apache 2.0)</a></p>
+    <div class="navbar navbar-expand">
+      <ul class="navbar-nav ms-auto">
+        {% for link in site.footer %}
+          {% assign active = nil %}
+          {% if page.url contains link.url %}
+            {% assign active = 'active' %}
+          {% endif %}
+
+          <li class="nav-item">
+           <a class="nav-link {{ active }}" href="{{ link.url }}" data-proofer-ignore>{% if link.icon %}<i class="fa {{ link.icon }}"></i> {% endif %}{{ link.title }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
   </div>
 </div>

--- a/_includes/github-repo-search.html
+++ b/_includes/github-repo-search.html
@@ -1,0 +1,1 @@
+https://github.com/search?q=org%3Avoxpupuli+fork%3Atrue+archived%3Afalse+topic%3A{{ include.topic}}+&type=repositories

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,11 @@
 
     <link rel="shortcut icon" href="{{site.url}}{{site.baseurl}}/favicon.ico" type="image/x-icon">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.7.2/css/fontawesome.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.7.2/css/solid.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.7.2/css/brands.min.css">
+
     <link rel="stylesheet" href="{{site.url}}{{site.baseurl}}/static/css/site.css">
     <link rel="stylesheet" href="{{site.url}}{{site.baseurl}}/static/css/syntax.css">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -6,21 +6,32 @@
   </button>
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav mr-auto">
-      {% for link in site.navigation %}
-        {% assign active = nil %}
-        {% if page.url contains link.url %}
-          {% assign active = 'active' %}
-        {% endif %}
-      <li class="nav-item">
-	<a class="nav-link {{ active }}" href="{{site.url}}{{site.baseurl}}{{ link.url }}" data-proofer-ignore>{{ link.title }}</a>
-      </li>
-      {% endfor %}
-    </ul>
     <ul class="navbar-nav ms-auto">
-      <li class="nav-item"><a class="nav-link{% if page.url contains "/privacy-policy" %} active{% endif %}" href="{{site.url}}{{site.baseurl}}/privacy-policy"> Privacy Policy</a></li>
-      <li class="nav-item"><a class="nav-link" href="https://github.com/voxpupuli"><i class="fa fa-github"></i> Github</a></li>
-      <li class="nav-item"><a class="nav-link" href="https://short.voxpupu.li/puppetcommunity_slack_signup"><i class="fa fa-slack"></i> Slack</a></li>
+      {% for item in site.navigation %}
+        {% if item.entries == nil %}
+          {% assign entries = "" | split: "," | push: item %}
+        {% else %}
+          {% assign entries = item.entries %}
+          <div class="submenu">
+          <span class="nav-header">{{ item.title }}</span>
+          <ul class="nav-menu ms-auto submenu-content">
+        {% endif %}
+
+        {% for link in entries %}
+          {% assign active = nil %}
+          {% if page.url contains link.url %}
+            {% assign active = 'active' %}
+          {% endif %}
+          <li class="nav-item">
+	         <a class="nav-link {{ active }}" href="{{ link.url }}" data-proofer-ignore>{% if link.icon %}<i class="fa {{ link.icon }}"></i> {% endif %}{{ link.title }}</a>
+          </li>
+        {% endfor %}
+
+        {% if item.entries != nil %}
+          </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
     </ul>
   </div>
   </div>

--- a/connect.md
+++ b/connect.md
@@ -1,0 +1,29 @@
+---
+layout: default
+---
+
+# Connect with us!
+
+You can get involved in the Vox Pupuli community by connecting at events,
+getting or giving help in any of our many channels, sharing modules on the
+Forge, contributing code, docs, or any of your valuable insights--and many other
+ways, too! However you decide to jump in, we know you’ll learn a lot and help
+advance our ecosystem.
+
+* The [`voxpupuli@groups.io` mailing list](https://groups.io/g/voxpupuli/topics)
+  is where you'll see announcements, blog notifications, official decision threads,
+  and others posted.
+    * Join by sending an [empty email](mailto:voxpupuli+subscribe@groups.io)
+    * Post via [voxpupuli@groups.io](mailto:voxpupuli+subscribe@groups.io)
+    * Browse [on the web](https://groups.io/g/voxpupuli/topics)
+* Many of our chat spaces are bridged together, so you can choose your favorite protocol.
+    * [IRC](ircs://irc.libera.chat:6697) by joining `#voxpupuli` on `irc.libera.chat` or via the [web interface](https://web.libera.chat/?#voxpupuli)
+    * [#voxpupuli](https://matrix.to/#/!xKkvgsGCsiWDhqCMMZ:libera.chat) on Matrix
+    * The `#voxpupuli` channel on [Puppet's Community Slack](https://voxpupuli.slack.com)
+        * *Note that Puppet's slack signups are broken, you'll need someone to invite you to join this space.*
+* Vox Pupuli has our own [Slack space](https://voxpupuli.slack.com) now with
+  channels for various interests.
+    * [Join the Vox Pupuli Slack](https://short.voxpupu.li/puppetcommunity_slack_signup)
+
+🔔 Note that our [Code of Conduct](/coc) applies in all community spaces and social
+interactions.

--- a/connect.md
+++ b/connect.md
@@ -19,7 +19,7 @@ advance our ecosystem.
 * Many of our chat spaces are bridged together, so you can choose your favorite protocol.
     * [IRC](ircs://irc.libera.chat:6697) by joining `#voxpupuli` on `irc.libera.chat` or via the [web interface](https://web.libera.chat/?#voxpupuli)
     * [#voxpupuli](https://matrix.to/#/!xKkvgsGCsiWDhqCMMZ:libera.chat) on Matrix
-    * The `#voxpupuli` channel on [Puppet's Community Slack](https://voxpupuli.slack.com)
+    * The `#voxpupuli` channel on [Puppet's Community Slack](https://puppetcommunity.slack.com)
         * *Note that Puppet's slack signups are broken, you'll need someone to invite you to join this space.*
 * Vox Pupuli has our own [Slack space](https://voxpupuli.slack.com) now with
   channels for various interests.

--- a/connect.md
+++ b/connect.md
@@ -14,7 +14,7 @@ advance our ecosystem.
   is where you'll see announcements, blog notifications, official decision threads,
   and others posted.
     * Join by sending an [empty email](mailto:voxpupuli+subscribe@groups.io)
-    * Post via [voxpupuli@groups.io](mailto:voxpupuli+subscribe@groups.io)
+    * Post via [voxpupuli@groups.io](mailto:voxpupuli@groups.io)
     * Browse [on the web](https://groups.io/g/voxpupuli/topics)
 * Many of our chat spaces are bridged together, so you can choose your favorite protocol.
     * [IRC](ircs://irc.libera.chat:6697) by joining `#voxpupuli` on `irc.libera.chat` or via the [web interface](https://web.libera.chat/?#voxpupuli)

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -3,7 +3,7 @@ layout: page
 title: Plugins
 ---
 
-This is a community curated list of plugins and tools for Puppet.
+This is a community curated list of plugins and tools for Puppet, some of which we host.
 
 Tools and plugins are defined in the `_data/tools` directory of the [community
 website repository](https://github.com/voxpupuli/voxpupuli.github.io)

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,65 @@
+---
+layout: default
+---
+
+# Projects Overview
+
+Vox Pupuli hosts many projects in the Puppet ecosystem. You're probably already
+using several of our modules and our testing pipeline tooling. This page will help
+you navigate our GitHub namespace and find just the repository you're looking for.
+
+We'd love to have your help, but please remember to check the [contribution guide](/contributing)
+before jumping in!
+
+## Puppet modules
+
+Most of the repositories in our namespace are [Puppet modules]({% include github-repo-search.html topic="puppet" %}).
+Most of our modules are also published on the Forge, and these are often the
+easiest projects to get involved with.
+
+### Platform Support
+
+* [Linux]({% include github-repo-search.html topic="linux-puppet-module" %})
+  * [Amazon Linux]({% include github-repo-search.html topic="amazon-puppet-module" %})
+  * [ArchLinux]({% include github-repo-search.html topic="archlinux-puppet-module" %})
+  * [CentOS]({% include github-repo-search.html topic="centos-puppet-module" %})
+  * [Debian]({% include github-repo-search.html topic="debian-puppet-module" %})
+  * [Gentoo]({% include github-repo-search.html topic="gentoo-puppet-module" %})
+  * [Oracle Linux]({% include github-repo-search.html topic="oraclelinux-puppet-module" %})
+  * [RedHat]({% include github-repo-search.html topic="redhat-puppet-module" %})
+  * [Scientific Linux]({% include github-repo-search.html topic="scientific-puppet-module" %})
+  * [SLES]({% include github-repo-search.html topic="sles-puppet-module" %})
+  * [Ubuntu]({% include github-repo-search.html topic="ubuntu-puppet-module" %})
+* [BSD]({% include github-repo-search.html topic="bsd-puppet-module" %})
+  * [FreeBSD]({% include github-repo-search.html topic="freebsd-puppet-module" %})
+  * [OpenBSD]({% include github-repo-search.html topic="openbsd-puppet-module" %})
+* [Windows]({% include github-repo-search.html topic="windows-puppet-module" %})
+
+
+## Infrastructure tools
+
+We host other projects you may wish to run in your infrastructure as well.
+
+* [Dashboards]({% include github-repo-search.html topic="dashboards" %})
+* [Monitoring]({% include github-repo-search.html topic="monitoring" %})
+* [Reporting tools]({% include github-repo-search.html topic="reporting" %})
+
+
+## Development tools
+
+Many of our projects are built to help developers and to run in testing pipelines.
+
+* [Puppet lint plugins]({% include github-repo-search.html topic="puppet-lint" %})
+* [Ruby Gems]({% include github-repo-search.html topic="ruby-gems" %})
+
+
+## Hacktoberfest
+
+During the month of October, we often participate in [Hacktoberfest](https://hacktoberfest.com).
+Remember that we have a great number of repositories and so you might have to nudge
+developers for a review. Take a look at the [Connect page](/connect) to see all
+the ways you can engage with us and work through your contributions. Read more about
+the [Hacktoberfest](https://hacktoberfest.com) project to see how it works.
+
+* [See all projects participating in Hacktoberfest]({% include github-repo-search.html topic="hacktoberfest" %})
+

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -51,6 +51,38 @@ ul.docs-index li:hover {
   padding-top: 30px;
 }
 
+.navbar .submenu {
+  position: relative;
+  display: inline-block;
+  min-width: 8em;
+}
+  .navbar .submenu .nav-header {
+    display: inline-block;
+    padding: 0.5em;
+  }
+  .navbar .submenu .submenu-content {
+    display: none;
+    position: absolute;
+    z-index: 100;
+    background-color: #3d8bfd;
+    min-width: 15em;
+    padding-left: 0.25em;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  }
+  .navbar .submenu .submenu-content li {
+    list-style-type: none;
+  }
+  .navbar .submenu .submenu-content li i {
+    min-width: 1.25em;
+  }
+  .navbar .submenu:hover .submenu-content {
+    display: block;
+  }
+  .navbar .submenu:hover .nav-header {
+    background-color: #3d8bfd;
+  }
+
+
 div.mermaid {
   border: 1px solid #aaa;
   background-color: white;


### PR DESCRIPTION
This takes the very busy navigation bars and reorganizes them into
dropdown menus. This gives us a lot more open space, but also lets have
a more intuitive navigation structure.

- moves the "connect with us" links from the footer into a nav menu.
  - also creates a `/connect` page that better explains what's bridged
    and how you can choose protocols to connect with.
- adds a Project Overview page with links to github repo lists
- configures the entire nav structure in `_config.yml` instead of some
  being hardcoded in the html
- adds the ability to add icons to any menu item.
  - if the icons aren't appreciated, just delete from the config
  - updated to current FontAwesome so the online search is usable

I did -not- make the money icon spin around, but I was tempted to.

If you like the overall look & feel, but want to adjust the menu
organization, can I suggest that we merge this and then contribute a
separate PR to reorganize?

This does not yet add any of the OpenPuppet pages. I'll do that in a
separate PR and then add navigation after we decide on a name.
