### PR TITLE
use the unstyled menu list on mobile

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -51,37 +51,42 @@ ul.docs-index li:hover {
   padding-top: 30px;
 }
 
-.navbar .submenu {
-  position: relative;
-  display: inline-block;
-  min-width: 8em;
-}
-  .navbar .submenu .nav-header {
+/* The unstyled list actually looks better on mobile. This width matches the
+   `navbar-expand-lg` parent class. If you change that, then change this to match.
+    See https://getbootstrap.com/docs/5.0/layout/breakpoints/#available-breakpoints
+ */
+@media (min-width: 991.98px) {
+  .navbar .submenu {
+    position: relative;
     display: inline-block;
-    padding: 0.5em;
+    min-width: 8em;
   }
-  .navbar .submenu .submenu-content {
-    display: none;
-    position: absolute;
-    z-index: 100;
-    background-color: #3d8bfd;
-    min-width: 15em;
-    padding-left: 0.25em;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-  }
-  .navbar .submenu .submenu-content li {
-    list-style-type: none;
-  }
-  .navbar .submenu .submenu-content li i {
-    min-width: 1.25em;
-  }
-  .navbar .submenu:hover .submenu-content {
-    display: block;
-  }
-  .navbar .submenu:hover .nav-header {
-    background-color: #3d8bfd;
-  }
-
+    .navbar .submenu .nav-header {
+      display: inline-block;
+      padding: 0.5em;
+    }
+    .navbar .submenu .submenu-content {
+      display: none;
+      position: absolute;
+      z-index: 100;
+      background-color: #3d8bfd;
+      min-width: 15em;
+      padding-left: 0.25em;
+      box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    }
+    .navbar .submenu .submenu-content li {
+      list-style-type: none;
+    }
+    .navbar .submenu .submenu-content li i {
+      min-width: 1.25em;
+    }
+    .navbar .submenu:hover .submenu-content {
+      display: block;
+    }
+    .navbar .submenu:hover .nav-header {
+      background-color: #3d8bfd;
+    }
+}
 
 div.mermaid {
   border: 1px solid #aaa;


### PR DESCRIPTION
The dropdown looks great on full size, but when we switch to the mobile
view, the unstyled list actually looks better. This breakpoint matches
the `navbar-expand-lg` parent class, so if that's changed, then this
should change to match. See https://getbootstrap.com/docs/5.0/layout/breakpoints/#available-breakpoints

Note that this will be easier to review if you set to ignore whitespace. All this does is add a breakpoint and indent some code to match.
