### PR TITLE
Consistent communication links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ write a plog post?
 Feel free to send us a pull request with your changes or raise an [issue](https://github.com/voxpupuli/voxpupuli.github.io/issues/new).
 We currently require all commits in this repo to be signed with gpg, so
 please configure your git client properly. Let us know if you need some help. We're also
-reachable via our IRC channel `#voxpupuli` on [Libera](https://web.libera.chat/?#voxpupuli),
-[`#voxpupuli:libera.chat`](https://matrix.to/#/!xKkvgsGCsiWDhqCMMZ:libera.chat) on Matrix,
+reachable via our IRC channel `#voxpupuli` on [Libera](https://web.libera.chat/?#voxpupuli)
 and [`#voxpupuli`](http://puppetcommunity.slack.com/messages/voxpupuli/) on the
 [Puppet Community Slack](http://slack.puppet.com).
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ write a plog post?
 Feel free to send us a pull request with your changes or raise an [issue](https://github.com/voxpupuli/voxpupuli.github.io/issues/new).
 We currently require all commits in this repo to be signed with gpg, so
 please configure your git client properly. Let us know if you need some help. We're also
-reachable via our IRC channel `#voxpupuli` on [Libera](https://web.libera.chat/?#voxpupuli)
+reachable via our IRC channel [#voxpupuli](ircs://irc.libera.chat:6697/voxpupuli) on
+[Libera.Chat](https://libera.chat/) ([webchat](https://web.libera.chat/?#voxpupuli))
 and [`#voxpupuli`](http://puppetcommunity.slack.com/messages/voxpupuli/) on the
 [Puppet Community Slack](http://slack.puppet.com).
 

--- a/_docs/about_vox_pupuli.md
+++ b/_docs/about_vox_pupuli.md
@@ -23,10 +23,8 @@ participation, orchestrated by github teams.
 
 We have a number of communication channels:
 
-* #voxpupuli on [Libera](https://web.libera.chat/?#voxpupuli), aka IRC
-* [#voxpupuli:libera.chat](https://matrix.to/#/!xKkvgsGCsiWDhqCMMZ:libera.chat) makes the IRC room available through Matrix clients such as [Element](https://element.io/)
-* [#voxpupuli](http://puppetcommunity.slack.com/messages/voxpupuli/) on
-  [Puppet Community](http://slack.puppet.com), aka Slack
+* IRC: [#voxpupuli](ircs://irc.libera.chat:6697/#voxpupuli) on [Libera.Chat](https://libera.chat/) ([webchat](https://web.libera.chat/?#voxpupuli))
+* [#voxpupuli](http://puppetcommunity.slack.com/messages/voxpupuli/) on [Puppet Community Slack](http://puppetcommunity.slack.com)
 * [Mailing List](https://groups.io/g/voxpupuli/)
 
 IRC still counts as the preferred point of contact for many of us but we tend

--- a/connect.md
+++ b/connect.md
@@ -17,7 +17,7 @@ advance our ecosystem.
     * Post via [voxpupuli@groups.io](mailto:voxpupuli@groups.io)
     * Browse [on the web](https://groups.io/g/voxpupuli/topics)
 * Many of our chat spaces are bridged together, so you can choose your favorite protocol.
-    * [IRC](ircs://irc.libera.chat:6697) by joining `#voxpupuli` on `irc.libera.chat` or via the [web interface](https://web.libera.chat/?#voxpupuli)
+    * IRC: [#voxpupuli](ircs://irc.libera.chat:6697/voxpupuli) on [Libera.Chat](https://libera.chat/) ([webchat](https://web.libera.chat/?#voxpupuli))
     * The `#voxpupuli` channel on [Puppet's Community Slack](https://puppetcommunity.slack.com)
         * *Note that Puppet's slack signups are broken, you'll need someone to invite you to join this space.*
 * Vox Pupuli has our own [Slack space](https://voxpupuli.slack.com) now with

--- a/connect.md
+++ b/connect.md
@@ -18,7 +18,6 @@ advance our ecosystem.
     * Browse [on the web](https://groups.io/g/voxpupuli/topics)
 * Many of our chat spaces are bridged together, so you can choose your favorite protocol.
     * [IRC](ircs://irc.libera.chat:6697) by joining `#voxpupuli` on `irc.libera.chat` or via the [web interface](https://web.libera.chat/?#voxpupuli)
-    * [#voxpupuli](https://matrix.to/#/!xKkvgsGCsiWDhqCMMZ:libera.chat) on Matrix
     * The `#voxpupuli` channel on [Puppet's Community Slack](https://puppetcommunity.slack.com)
         * *Note that Puppet's slack signups are broken, you'll need someone to invite you to join this space.*
 * Vox Pupuli has our own [Slack space](https://voxpupuli.slack.com) now with

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -8,7 +8,7 @@ title: How to Contribute
 Contributions are very welcome! We have hundreds of modules to care about, so any help is appreciated.
 If you want to contribute, you can start by looking at the [list of issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Avoxpupuli+archived%3Afalse+sort%3Acreated-desc) and see if there is something you can help with.
 
-We have a [mailinglist](https://groups.io/g/voxpupuli/), a [IRC channel](ircs://irc.libera.chat:6697) and a [slack channel](https://puppetcommunity.slack.com/messages/voxpupuli/) where you can ask questions and get in touch with us.
+We have a [mailinglist](https://groups.io/g/voxpupuli/), an [IRC channel](ircs://irc.libera.chat:6697/voxpupuli) and a [slack channel](https://puppetcommunity.slack.com/messages/voxpupuli/) where you can ask questions and get in touch with us.
 If you have any questions, don't hesitate to ask. We are happy to help you.
 
 ## Monthly sync

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -8,7 +8,7 @@ title: How to Contribute
 Contributions are very welcome! We have hundreds of modules to care about, so any help is appreciated.
 If you want to contribute, you can start by looking at the [list of issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Avoxpupuli+archived%3Afalse+sort%3Acreated-desc) and see if there is something you can help with.
 
-We have a [mailinglist](https://groups.io/g/voxpupuli/), a [IRC channel](ircs://irc.libera.chat:6697), a [slack channel](https://puppetcommunity.slack.com/messages/voxpupuli/) and a [matrix channel](https://matrix.to/#/!xKkvgsGCsiWDhqCMMZ:libera.chat) where you can ask questions and get in touch with us.
+We have a [mailinglist](https://groups.io/g/voxpupuli/), a [IRC channel](ircs://irc.libera.chat:6697) and a [slack channel](https://puppetcommunity.slack.com/messages/voxpupuli/) where you can ask questions and get in touch with us.
 If you have any questions, don't hesitate to ask. We are happy to help you.
 
 ## Monthly sync

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: Documentation
 ---
 
 This section is far from finished but contains some basic information on getting
-started. If you have any questions, reach out to us in #voxpupuli on [Libera](https://web.libera.chat/?#voxpupuli).
+started. If you have any questions, [reach out to us](/connect/).
 
 <ul class="docs-index">
 {% assign docs = site.docs | group_by: "layout" | first %}


### PR DESCRIPTION
This aims to make the chat URLs more consistent. The Slack links still aren't quite consistent, but I don't know exactly how that's supposed to work. See individual commit for details.