### PR TITLE
[docs] update url for vscode

### DIFF
--- a/_data/tools/editors-IDEs.json
+++ b/_data/tools/editors-IDEs.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "Visual Studio Code Extension for Puppet",
-      "url": "https://marketplace.visualstudio.com/items?itemName=jpogran.puppet-vscode",
+      "url": "https://marketplace.visualstudio.com/items?itemName=puppet.puppet-vscode",
       "description": "This extension provides full Puppet Language support for Visual Studio Code, including syntax highlighting, inline linting, autocomplete, PDK integration and compile debugging"
     },
     {


### PR DESCRIPTION
From https://marketplace.visualstudio.com/items?itemName=jpogran.puppet-vscode
> We are proud to announce that Official Puppet VS Code Extension is moving to the Puppetlabs namespace in the VS Code Marketplace!


