### PR TITLE
blogpost: Fix date 2024-02-04->2025-02-04

### DIFF
--- a/_posts/2025-02-04-new-release-workflow.md
+++ b/_posts/2025-02-04-new-release-workflow.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vox Pupuli Changelog - New Release process
-date: 2024-02-04
+date: 2025-02-04
 github_username: bastelfreak
 category: changelog
 ---


### PR DESCRIPTION
I was wondering why I didn't see the post in the RSS feed.