### PR TITLE
Refactor how pages describe interaction

### DIFF
--- a/_includes/connect_groups_io.md
+++ b/_includes/connect_groups_io.md
@@ -1,0 +1,8 @@
+## Mailing List
+
+The [`voxpupuli@groups.io` mailing list](https://groups.io/g/voxpupuli/topics)
+is where you'll see announcements, blog notifications, official decision threads,
+and others posted.
+* Join by sending an [empty email](mailto:voxpupuli+subscribe@groups.io)
+* Post via [voxpupuli@groups.io](mailto:voxpupuli@groups.io)
+* Browse [on the web](https://groups.io/g/voxpupuli/topics)

--- a/_includes/connect_irc.md
+++ b/_includes/connect_irc.md
@@ -1,0 +1,3 @@
+## IRC
+
+[#voxpupuli](ircs://irc.libera.chat:6697/voxpupuli) on [Libera.Chat](https://libera.chat/) ([webchat](https://web.libera.chat/?#voxpupuli)) (Bridged to `#voxpupuli` on Puppet Community Slack)

--- a/_includes/connect_slack.md
+++ b/_includes/connect_slack.md
@@ -1,0 +1,10 @@
+## Slack
+
+Vox Pupuli has our own [Slack space](https://voxpupuli.slack.com) with
+channels for projects and community organization.
+
+> [Join the Vox Pupuli Slack](https://short.voxpupu.li/puppetcommunity_slack_signup)
+
+There is also a `#voxpupuli` channel on the
+[Puppet Community Slack](https://puppetcommunity.slack.com) (You may need
+someone else to invite you) you can additionally find a `#voxpupuli` channel.

--- a/_includes/sync.md
+++ b/_includes/sync.md
@@ -1,0 +1,28 @@
+## Monthly Vox/Perforce Sync
+
+We have a monthly sync meeting where we discuss the state of the project and what we want to do in the future. You can find the [meeting board](https://github.com/orgs/voxpupuli/projects/10/) here. The [zoom link](https://perforce.zoom.us/j/92119937381?pwd=IK00nUw1GrmR9KNjtkbMSbQAzpboPu.1) is always the same, so you can join us every month. We meet every second Tuesday of the month at 16:30 [CET](https://www.timeanddate.com/time/zones/cet)/[CEST](https://www.timeanddate.com/time/zones/cest). You can [import this event in your calendar](voxpupuli-monthly-sync.ics).
+
+<p id="nextmeeting"></p>
+
+<script src="https://momentjs.com/downloads/moment.min.js"></script>
+<script src="https://momentjs.com/downloads/moment-timezone-with-data-10-year-range.js"></script>
+<script type="application/javascript">
+const myTimeZone = moment.tz.guess();
+const eventTimeZone = "Europe/Berlin";
+
+let nextMeeting = moment.tz(eventTimeZone).startOf('month').add(1, 'week').hours(16).minutes(30);
+dayOffset = 2 - nextMeeting.day();
+if (dayOffset < 0) dayOffset += 7;
+nextMeeting.add(dayOffset, 'days');
+
+if (nextMeeting.isBefore(moment.tz(eventTimeZone).subtract(1, 'hour'))) {
+  nextMeeting = moment.tz(eventTimeZone).startOf('month').add(1, 'month').add(1, 'week').hours(16).minutes(30);
+  dayOffset = 2 - nextMeeting.day();
+  if (dayOffset < 0) dayOffset += 7;
+  nextMeeting.add(dayOffset, 'days');
+}
+
+document.getElementById('nextmeeting').innerHTML += "Next monthly sync: " + nextMeeting.tz(myTimeZone).calendar() + " (" +
+ nextMeeting.tz(myTimeZone).format() + ")";
+</script>
+

--- a/connect.md
+++ b/connect.md
@@ -10,19 +10,13 @@ Forge, contributing code, docs, or any of your valuable insights--and many other
 ways, too! However you decide to jump in, we know you’ll learn a lot and help
 advance our ecosystem.
 
-* The [`voxpupuli@groups.io` mailing list](https://groups.io/g/voxpupuli/topics)
-  is where you'll see announcements, blog notifications, official decision threads,
-  and others posted.
-    * Join by sending an [empty email](mailto:voxpupuli+subscribe@groups.io)
-    * Post via [voxpupuli@groups.io](mailto:voxpupuli@groups.io)
-    * Browse [on the web](https://groups.io/g/voxpupuli/topics)
-* Many of our chat spaces are bridged together, so you can choose your favorite protocol.
-    * IRC: [#voxpupuli](ircs://irc.libera.chat:6697/voxpupuli) on [Libera.Chat](https://libera.chat/) ([webchat](https://web.libera.chat/?#voxpupuli))
-    * The `#voxpupuli` channel on [Puppet's Community Slack](https://puppetcommunity.slack.com)
-        * *Note that Puppet's slack signups are broken, you'll need someone to invite you to join this space.*
-* Vox Pupuli has our own [Slack space](https://voxpupuli.slack.com) now with
-  channels for various interests.
-    * [Join the Vox Pupuli Slack](https://short.voxpupu.li/puppetcommunity_slack_signup)
+{% include_relative _includes/connect_groups_io.md %}
+
+{% include_relative _includes/connect_irc.md %}
+
+{% include_relative _includes/connect_slack.md %}
+
+{% include_relative _includes/sync.md %}
 
 🔔 Note that our [Code of Conduct](/coc) applies in all community spaces and social
 interactions.

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -8,14 +8,15 @@ title: How to Contribute
 Contributions are very welcome! We have hundreds of modules to care about, so any help is appreciated.
 If you want to contribute, you can start by looking at the [list of issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Avoxpupuli+archived%3Afalse+sort%3Acreated-desc) and see if there is something you can help with.
 
-We have a [mailinglist](https://groups.io/g/voxpupuli/), an [IRC channel](ircs://irc.libera.chat:6697/voxpupuli) and a [slack channel](https://puppetcommunity.slack.com/messages/voxpupuli/) where you can ask questions and get in touch with us.
+{% include_relative ../_includes/connect_groups_io.md %}
+
+{% include_relative ../_includes/connect_slack.md %}
+
+{% include_relative ../_includes/connect_irc.md %}
+
 If you have any questions, don't hesitate to ask. We are happy to help you.
 
-## Monthly sync
-
-We have a monthly sync meeting where we discuss the state of the project and what we want to do in the future. You can find the [meeting board](https://github.com/orgs/voxpupuli/projects/10/) here. The [zoom link](https://perforce.zoom.us/j/92119937381?pwd=IK00nUw1GrmR9KNjtkbMSbQAzpboPu.1) is always the same, so you can join us every month. We meet every second tuesday of the month at 16:30 [CET](https://www.timeanddate.com/time/zones/cet)/[CEST](https://www.timeanddate.com/time/zones/cest). You can [import this event in your calendar](voxpupuli-monthly-sync.ics).
-
-<p id="nextmeeting"></p>
+{% include_relative ../_includes/sync.md %}
 
 ## Guidelines
 
@@ -25,24 +26,3 @@ We have a monthly sync meeting where we discuss the state of the project and wha
 - General and more specific documentation can be found on our [docs](https://voxpupuli.org/docs/).
 - In the project you want to work on, check their own contribution guidelines most often found in the README.md or CONTRIBUTING.md file.
 
-<script src="https://momentjs.com/downloads/moment.min.js"></script>
-<script src="https://momentjs.com/downloads/moment-timezone-with-data-10-year-range.js"></script>
-<script type="application/javascript">
-const myTimeZone = moment.tz.guess();
-const eventTimeZone = "Europe/Berlin";
-
-let nextMeeting = moment.tz(eventTimeZone).startOf('month').add(1, 'week').hours(16).minutes(30);
-dayOffset = 2 - nextMeeting.day();
-if (dayOffset < 0) dayOffset += 7;
-nextMeeting.add(dayOffset, 'days');
-
-if (nextMeeting.isBefore(moment.tz(eventTimeZone).subtract(1, 'hour'))) {
-  nextMeeting = moment.tz(eventTimeZone).startOf('month').add(1, 'month').add(1, 'week').hours(16).minutes(30);
-  dayOffset = 2 - nextMeeting.day();
-  if (dayOffset < 0) dayOffset += 7;
-  nextMeeting.add(dayOffset, 'days');
-}
-
-document.getElementById('nextmeeting').innerHTML += "Next monthly sync: " + nextMeeting.tz(myTimeZone).calendar() + " (" +
- nextMeeting.tz(myTimeZone).format() + ")";
-</script>


### PR DESCRIPTION
Connect had Slack/IRC/Mailing Lists
Contributing had short versions of the Slack/IRC/Mailing List, but also had the Monthly Sync.  This moves each of those into its own include and then puts all of them on both pages.