### PR TITLE
Remove outdated incoming-migrations team reference

### DIFF
--- a/_docs/migrate_module.md
+++ b/_docs/migrate_module.md
@@ -7,7 +7,6 @@ summary: Complete directions for migrating a module to Vox Pupuli, including the
 
 You will have someone by your side in this process. The general flow is to…
 
-* Ask one of the Administrators to add you to the `incoming-migrations` team.
 * Prepare your repo for transfer
     * If this module was created with PDK delete .sync.yaml.
     * Ensure that the module has a correct `LICENSE` file in the docroot that matches the mentioned license in the `metadata.json`.

--- a/_docs/migrate_module.md
+++ b/_docs/migrate_module.md
@@ -21,7 +21,7 @@ You will have someone by your side in this process. The general flow is to…
 * Execute [modulesync][msync] for this module.
 * Our modulesync will delete a `CONTRIBUTING.md` in the root directory and place one at `.github/CONTRIBUTING.md`. Please enhance [our existing template][template] if the version in the docroot contains useful parts.
 * [Release][release] the first version under Vox Pupuli.
-* Creata a GitHub issue for the [FORGE][forge] project and ask to deprecate the old module (and approve the new one if the old one was approved as well).
+* Create a GitHub issue for the [FORGE][forge] project and ask to deprecate the old module (and approve the new one if the old one was approved as well).
 * Do you think the module qualifies to be approved? Wait until it is released, then raise a [GitHub Issue][approve] in the Puppetlabs organisation.
 * Write a very short blog post about the migration([example][example]). Write to our [mailinglist](mailto:voxpupuli@groups.io) about the migration/new blogpost.
 


### PR DESCRIPTION
Back in the day the incoming-migrations team had permissions to create
repositories, which allowed migrations. These days GitHub no longer has
team specific repo-create permission and it's a global setting.
