### PR TITLE
Use sticky PR comment only for branches from origin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,9 @@ jobs:
           overwrite: true
           compression-level: 9
           if-no-files-found: error
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - name: Post comment to PR with download link
+        if: github.repository == 'voxpupuli/voxpupuli.github.io'
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |
             Download / Review a preview of this change at, ${{ steps.upload-preview.outputs.artifact-url }} (for the next 7 days.)


### PR DESCRIPTION
the action only works when the base branch is in the Vox Pupuli org.