### PR TITLE
Simplify the install page

### DIFF
--- a/openvox/install.md
+++ b/openvox/install.md
@@ -9,13 +9,20 @@ As of release 8.11, OpenVox is functionally equivalent to Puppet; the command na
 The major differences are in help text output, man pages, and so on.
 This means that you can continue to use all the commands, modules, tooling, etc that you're used to, but at this time *you cannot install both Puppet and OpenVox on the same system*.
 
+> 🔔 Tip: If you want to use Puppet code to manage your systems, if you have strange dependencies, if you're migrating from Puppet Enterprise, or if you have Puppet modules installed as system packages then see the [advanced options](#advanced-options) sections below.
+>
+> * [Alternative Puppet uninstallation options](#alternative-puppet-uninstallation-options)
+> * [Managing OpenVox with OpenVox](#managing-openvox-with-openvox)
+>     * [Managing Repositories](#managing-repositories)
+>     * [Managing the Server/Client](#managing-the-serverclient)
+>     * [Foreman Integration](#foreman-integration)
+{: class="alert alert-primary callout" }
+
 We encourage you to try out OpenVox on a fresh test system, the way you would for any major system package.
 If you'd rather try it on an existing system or develop a migration process, then the new OpenVox packages will uninstall and replace the existing legacy Puppet packages.
 
 You do not need to purge configuration files because OpenVox will continue to use them as they are.
 However, **before getting started on the migration you should strongly consider backing up the entire `/etc/puppetlabs/` tree** in case of accidents.
-
-*🔔 Tip: If you have strange dependencies, you're migrating from Puppet Enterprise, or if you have Puppet modules installed as system packages then see the [advanced options](#advanced-options) sections below.*
 
 First enable the repository, based on your Linux distribution.
 Choose the appropriate `openvox8-release` repo package from either of these locations and install it.

--- a/openvox/install.md
+++ b/openvox/install.md
@@ -9,30 +9,13 @@ As of release 8.11, OpenVox is functionally equivalent to Puppet; the command na
 The major differences are in help text output, man pages, and so on.
 This means that you can continue to use all the commands, modules, tooling, etc that you're used to, but at this time *you cannot install both Puppet and OpenVox on the same system*.
 
-## Uninstalling Puppet
-
 We encourage you to try out OpenVox on a fresh test system, the way you would for any major system package.
-If you'd rather try it on an existing system or develop a migration process, then simply installing OpenVox will uninstall Puppet.
+If you'd rather try it on an existing system or develop a migration process, then the new OpenVox packages will uninstall and replace the existing legacy Puppet packages.
 
 You do not need to purge configuration files because OpenVox will continue to use them as they are.
 However, **before getting started on the migration you should strongly consider backing up the entire `/etc/puppetlabs/` tree** in case of accidents.
 
-* If you're migrating from Puppet Enterprise you can use the `puppet-enterprise-uninstaller` script on each node as described in [their docs](https://www.puppet.com/docs/pe/latest/uninstalling.html).
-* If you're using the all-in-one packages such as `puppet-agent` or `puppetserver` from the `[apt|yum].puppet.com` repos, simply remove these packages.
-* If you're using distro provided packages, then you might have a bigger job.
-  For example, if you're using Debian packages, you may have several Puppet modules packaged as `.deb` packages that you'll have to move to your `Puppetfile`.
-  You might consider waiting until your distro packages OpenVox.
-    * If you do want to migrate now, then remove any puppet packages and dependencies you have installed using your distro tools.
-        * Debian family
-          * `apt autoremove <packagename>`
-        * RedHat family
-          * `yum autoremove <packagename>`
-    * You might also consider (carefully) cleaning up unused dependencies afterwards by running `apt` or `yum` autoremove without a package name.
-
-You do not need to remove the `[apt|yum].puppet.com` repositories although the only thing you'll be able to use them for going forward is installing historical Puppet releases.
-
-
-## Installation
+*🔔 Tip: If you have strange dependencies, you're migrating from Puppet Enterprise, or if you have Puppet modules installed as system packages then see the [advanced options](#advanced-options) sections below.*
 
 First enable the repository, based on your Linux distribution.
 Choose the appropriate `openvox8-release` repo package from either of these locations and install it.
@@ -57,9 +40,34 @@ Then install the packages you want.
 
 If you have backed up config files, then restore them now.
 
+### 🎉 That's it! You're done!
+Feel free to read the rest of the page for more options.
+
+-----
+
+## Advanced Options
+
+### Alternative Puppet uninstallation options
+
+There are some cases in which you might have to take more steps to safely remove legacy Puppet from your system.
+
+* If you're migrating from Puppet Enterprise you can use the `puppet-enterprise-uninstaller` script on each node as described in [their docs](https://www.puppet.com/docs/pe/latest/uninstalling.html).
+* If you're using distro provided packages, then you might have a bigger job.
+  For example, if you're using Debian packages, you may have several Puppet modules packaged as `.deb` packages that you'll have to move to your `Puppetfile`.
+  You might consider waiting until your distro packages OpenVox.
+    * If you do want to migrate now, then remove any puppet packages and dependencies you have installed using your distro tools.
+        * Debian family
+          * `apt autoremove <packagename>`
+        * RedHat family
+          * `yum autoremove <packagename>`
+    * You might also consider (carefully) cleaning up unused dependencies afterwards by running `apt` or `yum` autoremove without a package name.
+
+You do not need to remove the `[apt|yum].puppet.com` repositories although the only thing you'll be able to use them for going forward is installing historical Puppet releases.
+
+
 ### Managing OpenVox with OpenVox
 
-### Repositories
+#### Managing Repositories
 
 You can add the APT or YUM repositories with OpenVox - this should do the same thing as using the release packages:
 
@@ -94,7 +102,7 @@ yum::install { "openvox${release}-release":
 }
 ```
 
-### Server/Client
+#### Managing the Server/Client
 
 You can manage OpenVox with several existing modules:
 
@@ -112,24 +120,26 @@ puppetdb::puppetdb_package: openvoxdb
 puppetdb::master::config::terminus_package: openvoxdb-termini
 ```
 
-Note that this will cause errors if the OpenVox repositories are not available (using one of the methods above).
+Note that you will need to have the OpenVox repositories available (using one of the methods above) for this to work properly.
 If the OpenVox repositories are available, this will cause Puppet to be removed and OpenVox to be installed.
 
 
-### Foreman integration
+#### Foreman integration
 
-Foreman installs the package puppet-agent-oauth.
-It provides the [oauth](https://rubygems.org/gems/oauth) gem for the Puppet Agent Ruby.
-The package depends on `puppet-agent`.
-The OpenVox packages don't have a `provides puppet-agent` flag yet.
-As a workaround, tell the foreman module to not install the package:
+Foreman installs the package `puppet-agent-oauth` which is a system packaged Ruby gem with native code.
+It provides the [oauth](https://rubygems.org/gems/oauth) gem for the Puppet Agent Ruby environment and depends on `puppet-agent`.
+The OpenVox packages don't have a `provides puppet-agent` flag yet, so this will cause dependency errors.
+As a workaround you'll need to manage the gem directly instead of letting the Foreman module handle it.
+Note that this will require build essentials and ruby development packages.
+
+Add this to your Hiera config:
 
 ```yaml
 ---
 foreman::providers::oauth: false
 ```
 
-And manage the gem directly:
+And then manage the gem directly in Puppet code:
 
 ```puppet
 package { 'oauth':
@@ -137,6 +147,8 @@ package { 'oauth':
   provider => 'puppet_gem',
 }
 ```
+
+-----
 
 ## Sponsorship
 

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -118,6 +118,12 @@ section.content {
   margin: 1em 0;
 }
 
+.callout {
+  width: 45%;
+  float: right;
+  font-style: italic;
+}
+
 /* bootstrap customizations */
 .w-33 {
     width: 33%!important;


### PR DESCRIPTION
The install page was starting to look a lot more complex than it had to
be. This simply focuses on the "easy path" and moves everything else down
to an "advanced" section.
