### PR TITLE
add 'more info' message back

### DIFF
--- a/voxconf.md
+++ b/voxconf.md
@@ -28,7 +28,7 @@ title: VoxConf '25
     </tr>
     <tr>
       <th scope="row">Register:</th>
-      <td><a href="https://tickets.netways.de/NES/foremanbirthday/">click here!</a></td>
+      <td><p class="fst-italic"><a href="https://tickets.netways.de/NES/foremanbirthday/">click here!</a><br/>👇Scroll down for more information ⬇️</p></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This message was to ensure that people saw that there was more info on the page, like the travel budget and the cfp and whatnot.