### PR TITLE
Updating the sync link to Vox managed

### DIFF
--- a/_includes/sync.md
+++ b/_includes/sync.md
@@ -1,6 +1,10 @@
 ## Monthly Vox/Perforce Sync
 
-We have a monthly sync meeting where we discuss the state of the project and what we want to do in the future. You can find the [meeting board](https://github.com/orgs/voxpupuli/projects/10/) here. The [zoom link](https://perforce.zoom.us/j/98887923135?pwd=m3AI7IngqwJCHq6LiJep2bJgCOvobh.1&jst=1) has changed a few time, we try to keep the website up-to-date when this happen. We meet every second Tuesday of the month at 16:30 [CET](https://www.timeanddate.com/time/zones/cet)/[CEST](https://www.timeanddate.com/time/zones/cest). You can [import this event in your calendar](/contributing/voxpupuli-monthly-sync.ics).
+We have a monthly sync meeting where we discuss the state of the project and what we want to do in the future.
+You can find the [meeting board](https://github.com/orgs/voxpupuli/projects/10/) here.
+The [meeting link](https://meet.google.com/jti-ktoz-sfr) has changed a few times, we try to keep the website up-to-date when this happen.
+We meet every second Tuesday of the month at 16:30 [CET](https://www.timeanddate.com/time/zones/cet)/[CEST](https://www.timeanddate.com/time/zones/cest).
+You can [import this event in your calendar](/contributing/voxpupuli-monthly-sync.ics).
 
 <p id="nextmeeting"></p>
 

--- a/contributing/voxpupuli-monthly-sync.ics
+++ b/contributing/voxpupuli-monthly-sync.ics
@@ -45,9 +45,9 @@ DTSTAMP:20241227T225300Z
 CREATED:20241227T225300Z
 UID:6A104D48-6E0B-455A-8287-A15FB58FD654
 LAST-MODIFIED:20250502T180046Z
+X-GOOGLE-CONFERENCE:https://meet.google.com/jti-ktoz-sfr
 DESCRIPTION:Meeting Board:\nhttps://github.com/orgs/voxpupuli/projects/10/\
- n\nZoom:\nhttps://perforce.zoom.us/j/98887923135?pwd=m3AI7IngqwJCHq6LiJep2
- bJgCOvobh.1&jst=1\n\nMeeting ID: 988 8792 3135\nPasscode: 962143
+ n\nMeeting link: https://meet.google.com/jti-ktoz-sfr
 SUMMARY:Vox Pupuli Monthly Sync
 LOCATION:Online
 DTSTART;TZID=Europe/Berlin:20241210T163000
@@ -59,8 +59,7 @@ TRIGGER;RELATED=START;VALUE=DURATION:-PT1H
 ACTION:DISPLAY
 SUMMARY:Vox Pupuli Monthly Sync
 DESCRIPTION:Meeting Board:\nhttps://github.com/orgs/voxpupuli/projects/10/\
- n\nZoom:\nhttps://perforce.zoom.us/j/98887923135?pwd=m3AI7IngqwJCHq6LiJep2
- bJgCOvobh.1&jst=1\n\nMeeting ID: 988 8792 3135\nPasscode: 962143
+ n\nMeeting link: https://meet.google.com/jti-ktoz-sfr
 END:VALARM
 RRULE:FREQ=MONTHLY;BYDAY=2TU
 END:VEVENT


### PR DESCRIPTION
We've decided to center Vox Pupuli, so we're switching the meeting link
to one managed by Vox Pupuli PMC.
