### PR TITLE
Remove AllCompilers in load balance arch diagram

### DIFF
--- a/_docs/arch_load_balanced.md
+++ b/_docs/arch_load_balanced.md
@@ -17,7 +17,6 @@ that require the redundancy of multiple compilers.
   git(Git Repository)
   Foreman(The Foreman)
   Webhook(webhook-go)
-  AllCompilers((All Compilers))
   HDM(Hiera Data Manager)
 
   MainOpenVoxServer{Main OpenVox Server}
@@ -40,7 +39,7 @@ that require the redundancy of multiple compilers.
 
   git --webhook--> Webhook
   Webhook --r10k code deploy--> MainOpenVoxServer
-  Webhook -.r10k code deploy.-> AllCompilers
+  Webhook -.r10k code deploy.-> Compilers
 
   Foreman --> MainOpenVoxServer
   MainOpenVoxServer --> Foreman


### PR DESCRIPTION
Remove the AllCompilers group and have r10k deploy to the Compilers group in the load-balanced arch diagram.

Fixes https://github.com/voxpupuli/voxpupuli.github.io/issues/574
