### PR TITLE
remove broken breadcrumb hyperlinks

### DIFF
--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,2 +1,4 @@
 port: 4000
 url: 'http://localhost:4000'
+exclude:
+  - .idea

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -2,12 +2,9 @@
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="/">Home</a></li>
-    {% for crumb in crumbs offset: 1 %}
-      {% if forloop.last %}
-        <li class="breadcrumb-item active" aria-current="page">{{ crumb | replace:'-',' ' | remove:'.html' | capitalize }}</li>
-      {% else %}
-        <li class="breadcrumb-item"><a href="{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' | replace:'without-plugin/','without-plugins/' }}{% endfor %}">{{ crumb | replace:'-',' ' | remove:'.html' | capitalize }}</a></li>
-      {% endif %}
+    <li class="breadcrumb-item"><a href="/blog/">Blog</a></li>
+    {% for crumb in crumbs offset: 2 %}
+      <li class="breadcrumb-item active" aria-current="page">{{ crumb | replace:'-',' ' | remove:'.html' | capitalize }}</li>
     {% endfor %}
   </ol>
 </nav>


### PR DESCRIPTION
# remove broken breadcrumb hyperlinks

- since jekyll-archives plugin is not allowed in GitHub Pages we will no longer link to the non-existent date-based archives (until a solution is found)
- manually create the /blog/ link
- start iterating over crumbs (created from splitting of URL on /) with offset 2
- simply display the crumb