### PR TITLE
bring back breadcrumbs

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -2,9 +2,29 @@
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="/">Home</a></li>
-    <li class="breadcrumb-item"><a href="/blog/">Blog</a></li>
-    {% for crumb in crumbs offset: 2 %}
-      <li class="breadcrumb-item active" aria-current="page">{{ crumb | replace:'-',' ' | remove:'.html' | capitalize }}</li>
+    {% for crumb in crumbs offset: 1 %}
+      {% assign stripped = crumb
+      | replace: '0', ''
+      | replace: '1', ''
+      | replace: '2', ''
+      | replace: '3', ''
+      | replace: '4', ''
+      | replace: '5', ''
+      | replace: '6', ''
+      | replace: '7', ''
+      | replace: '8', ''
+      | replace: '9', '' %}
+
+      {%- assign crumb_is_numeric = false -%}
+      {% if crumb != '' and stripped == '' %}
+      {%- assign crumb_is_numeric = true -%}
+      {% endif %}
+
+      {% if forloop.last or crumb_is_numeric %}
+        <li class="breadcrumb-item active" aria-current="page">{{ crumb | replace:'-',' ' | remove:'.html' | capitalize }}</li>
+      {% else %}
+        <li class="breadcrumb-item"><a href="{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' | replace:'without-plugin/','without-plugins/' }}{% endfor %}">{{ crumb | replace:'-',' ' | remove:'.html' | capitalize }}</a></li>
+      {% endif %}
     {% endfor %}
   </ol>
 </nav>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -37,10 +37,10 @@
   </div>
 </nav>
 
-{% if page.subsection %}
-{% include subsection.html %}
-{% endif %}
-
 <div class="container pt-3">
   {% include breadcrumbs.html %}
 </div>
+
+{% if page.subsection %}
+{% include subsection.html %}
+{% endif %}


### PR DESCRIPTION
- previous commit broke breadcrumbs for pages which include subsections, e.g., `openvox/index.md`
- bring back breadcrumbs
- detect when a breadcrumb is completely numeric and skip hyperlinking
- fix order of display of subsections and breadcrumbs