### PR TITLE
Update how_to_run_tests.md

### DIFF
--- a/_docs/how_to_run_tests.md
+++ b/_docs/how_to_run_tests.md
@@ -60,7 +60,7 @@ Use the appropriate package manager to get it installed.
 #### ArchLinux
 
 ```shell
-# pacman -Syu extra/ruby-bundler
+# pacman -S ruby-bundler
 ```
 
 #### By Gem (Last Option)


### PR DESCRIPTION
Fixing Arch Linux installation instructions. 

`pacman -Syu` runs an upgrade, and defining the repo is incorrect. The correct command is simply `pacman -S ruby-bundler`.