### PR TITLE
Add a little styling to post info

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 <h1>{{ page.title }}
   {% include edit_button.html %}
 </h1>
-<p>Published on {{ page.date | date: "%b %-d, %Y" }}{% if page.github_username %} by <a href="https://github.com/{{page.github_username}}">{{ page.github_username }}</a>{% endif %}.{% assign published = page.date | date: "%Y-%m-%d" %}{% assign updated = page.last_modified_at | date: "%Y-%m-%d" %}{% if page.last_modified_at and updated != published %} Last updated on {{ page.last_modified_at | date: "%b %-d, %Y" }}{% if page.last_updater %} by <a href="https://github.com/{{page.last_updater}}">{{ page.last_updater }}</a>{% endif %}.{% endif %}</p>
+<p class="article-meta">Published on {{ page.date | date: "%b %-d, %Y" }}{% if page.github_username %} by <a href="https://github.com/{{page.github_username}}">{{ page.github_username }}</a>{% endif %}.{% assign published = page.date | date: "%Y-%m-%d" %}{% assign updated = page.last_modified_at | date: "%Y-%m-%d" %}{% if page.last_modified_at and updated != published %} Last updated on {{ page.last_modified_at | date: "%b %-d, %Y" }}{% if page.last_updater %} by <a href="https://github.com/{{page.last_updater}}">{{ page.last_updater }}</a>{% endif %}.{% endif %}</p>
 <article>
   {{ content }}
 </article>

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -25,6 +25,11 @@
   line-height: 1.4em;
 }
 
+.content .article-meta {
+  font-size: smaller;
+  font-style: italic;
+  border-bottom: 1px solid #d3d3d3;
+}
 /* minimal styling for the docs index page listing */
 ul.docs-index {
   list-style-type: none;


### PR DESCRIPTION
Now that we're also including last updated date, the post info feels a
bit heavy. This makes the text a little smaller and underlines it for a
clean separation between metadata and content.

This is visible on any page that uses the `post` layout -- the blog and
documentation pages.

Signed-off-by: Ben Ford <binford2k@overlookinfratech.com>
